### PR TITLE
Librabry version updates & pins for older ruby/puppet-lint version

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -35,5 +35,5 @@ jobs:
       with:
         ruby-version: ${{ matrix.ruby-version }}
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically
-    - name: Run tests, as defined in default rake command
-      run: bundle exec rake
+    - name: Run tests, as defined in rake "test" task
+      run: bundle exec rake test

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,8 +1,12 @@
+plugins:
+    - 'rubocop-rake'
+
 AllCops:
+  NewCops: 'enable'
   TargetRubyVersion: 2.7
-  NewCops: enable
   Exclude:
     - 'spec/fixtures/**/*'
+    - 'vendor/**/*'
 
 Layout/LineLength:
   Max: 100

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gem 'rake'
 
 group :test do
   gem 'puppetlabs_spec_helper'
-  gem 'puppet-lint'
+  gem 'puppet-lint', '~>2.5.2'
   gem 'rspec-puppet', '~>2.8.0'
   gem 'rspec-puppet-utils'
   gem 'rubocop'

--- a/Rakefile
+++ b/Rakefile
@@ -6,6 +6,8 @@ CLEAN.include('spec/fixtures/')
 
 require 'puppetlabs_spec_helper/rake_tasks'
 
+RuboCop::RakeTask.new
+
 PuppetLint::RakeTask.new :lint do |config|
   # Pattern of files to check, defaults to `**/*.pp`
   config.pattern = 'manifests/**/*.pp'
@@ -13,5 +15,4 @@ PuppetLint::RakeTask.new :lint do |config|
   config.with_context = true
 end
 
-task test: %w[rubocop lint spec]
-task default: %i[clean test]
+task test: %w[clean rubocop lint spec]

--- a/manifests/centos.pp
+++ b/manifests/centos.pp
@@ -1,3 +1,4 @@
+# CentOS specific installer manifest
 class pritunl::centos {
   package { 'epel-release': }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,8 +1,9 @@
-# A class to install and manage a Pritunl VPN server
+# Top-level class for convenience to installer logic
 class pritunl {
   include pritunl::install
 }
 
+# A class to install and manage a Pritunl VPN server
 class pritunl::install {
   case $::facts['os']['name'] {
     'CentOS': { require pritunl::centos }

--- a/manifests/ubuntu.pp
+++ b/manifests/ubuntu.pp
@@ -1,3 +1,4 @@
+# Ubuntu specific installer manifest
 class pritunl::ubuntu {
 #  apt::key { 'pritunl':
 #    id => '7568D9BB55FF9E5287D586017AE645C0CF8E292A',

--- a/spec/classes/centos_spec.rb
+++ b/spec/classes/centos_spec.rb
@@ -15,7 +15,7 @@ describe 'pritunl::centos' do
       ).render
     end
 
-    it { is_expected.to contain_file('/etc/pki/rpm-gpg/RPM-GPG-KEY-pritunl')\
+    it { is_expected.to contain_file('/etc/pki/rpm-gpg/RPM-GPG-KEY-pritunl')
       .with_content(/BEGIN PGP PUBLIC KEY BLOCK/)
     }
     it { is_expected.to contain_package('pritunl') }


### PR DESCRIPTION
Adds missing puppet manifest class documentation
Require puppet-lint version that supports plugins
Automatically load the rubocop-rake linter task
Added auto-corrections of updated rubocop linter