### PR TITLE
Added Ruby 3.2 support

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,3 +1,0 @@
-fixtures:
-  symlinks:
-    pritunl: "#{source_dir}"

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['2.7']
+        ruby-version: ['2.7', '3.2']
 
     steps:
     - uses: actions/checkout@v4

--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,3 @@
+--color
+--format documentation
+

--- a/Gemfile
+++ b/Gemfile
@@ -1,13 +1,12 @@
 source 'https://rubygems.org'
 
-ruby '~>2.0'
-
+gem 'puppet', '~>7.0'
 gem 'rake'
 
 group :test do
-  gem 'puppetlabs_spec_helper'
-  gem 'puppet-lint', '~>2.5.2'
-  gem 'rspec-puppet', '~>2.8.0'
+  gem 'puppetlabs_spec_helper', '~>5.0'
+  gem 'puppet-lint'
+  gem 'rspec-puppet'
   gem 'rspec-puppet-utils'
   gem 'rubocop'
   gem 'rubocop-rake'

--- a/Rakefile
+++ b/Rakefile
@@ -6,8 +6,6 @@ CLEAN.include('spec/fixtures/')
 
 require 'puppetlabs_spec_helper/rake_tasks'
 
-RuboCop::RakeTask.new
-
 PuppetLint::RakeTask.new :lint do |config|
   # Pattern of files to check, defaults to `**/*.pp`
   config.pattern = 'manifests/**/*.pp'

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -3,9 +3,9 @@ require 'spec_helper'
 describe 'pritunl' do
   context 'when using unknown OS it should fail' do
     let(:title) { 'pritunl' }
-    let(:facts) { { os: { name: 'fail' } } }
+    let(:facts) { { os: { name: 'RedHat' } } }
 
-    it { is_expected.to compile.and_raise_error(/'fail' not supported/) }
+    it { is_expected.to compile.and_raise_error(/not supported/) }
   end
 
   context 'when using centos' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,11 +1,13 @@
-RSpec.configure do |c|
-  c.mock_with :rspec
-  c.before(:each) do
-    # Puppet::Util::Log.level = :warning
-    # Puppet::Util::Log.newdestination(:console)
-  end
-end
-
-require 'puppetlabs_spec_helper/module_spec_helper'
 require 'rspec-puppet'
 require 'rspec-puppet-utils'
+
+fixture_path = File.expand_path(File.join(__FILE__, '..', 'fixtures'))
+
+RSpec.configure do |c|
+  c.module_path = File.join(fixture_path, 'modules')
+  c.mock_with :rspec
+  c.before(:each) do
+    Puppet::Util::Log.level = :warning
+    Puppet::Util::Log.newdestination(:console)
+  end
+end


### PR DESCRIPTION
Allow Gemfile version pins floating for broader Ruby 2.7/3.x support Removed redundant test fixtures
Improved default rspec test output format for readability